### PR TITLE
Rename BlobstoreClientCertificatesPath

### DIFF
--- a/commands/config/builder.go
+++ b/commands/config/builder.go
@@ -25,13 +25,13 @@ type Config struct {
 }
 
 type Create struct {
-	ExcludeImageFromQuota           bool     `yaml:"exclude_image_from_quota"`
-	SkipLayerValidation             bool     `yaml:"skip_layer_validation"`
-	WithClean                       bool     `yaml:"with_clean"`
-	WithoutMount                    bool     `yaml:"without_mount"`
-	DiskLimitSizeBytes              int64    `yaml:"disk_limit_size_bytes"`
-	InsecureRegistries              []string `yaml:"insecure_registries"`
-	BlobstoreClientCertificatesPath string   `yaml:"blobstore_client_certificates_path"`
+	ExcludeImageFromQuota             bool     `yaml:"exclude_image_from_quota"`
+	SkipLayerValidation               bool     `yaml:"skip_layer_validation"`
+	WithClean                         bool     `yaml:"with_clean"`
+	WithoutMount                      bool     `yaml:"without_mount"`
+	DiskLimitSizeBytes                int64    `yaml:"disk_limit_size_bytes"`
+	InsecureRegistries                []string `yaml:"insecure_registries"`
+	RemoteLayerClientCertificatesPath string   `yaml:"remote_layer_client_certificates_path"`
 }
 
 type Clean struct {

--- a/commands/create.go
+++ b/commands/create.go
@@ -286,7 +286,7 @@ func createSystemContext(baseImageURL *url.URL, createConfig config.Create, user
 		}
 	case "oci":
 		return types.SystemContext{
-			OCICertPath: createConfig.BlobstoreClientCertificatesPath,
+			OCICertPath: createConfig.RemoteLayerClientCertificatesPath,
 		}
 	default:
 		return types.SystemContext{}

--- a/integration/create_oci_test.go
+++ b/integration/create_oci_test.go
@@ -453,7 +453,7 @@ var _ = Describe("Create with OCI images", func() {
 		It("creates an image", func() {
 			cfg := config.Config{
 				Create: config.Create{
-					BlobstoreClientCertificatesPath: "assets/certs",
+					RemoteLayerClientCertificatesPath: "assets/certs",
 				},
 			}
 			Expect(runner.SetConfig(cfg)).To(Succeed())


### PR DESCRIPTION
Depends on https://github.com/cloudfoundry/grootfs-release/pull/8

RemoteLayerClientCertificatesPath is a more accurate name.

[#151724164]