### PR TITLE
A failed stats command should not mention deletion

### DIFF
--- a/commands/delete.go
+++ b/commands/delete.go
@@ -45,7 +45,7 @@ var DeleteCommand = cli.Command{
 		id, err := idfinder.FindID(storePath, idOrPath)
 		if err != nil {
 			logger.Debug("id-not-found-skipping", lager.Data{"id": idOrPath, "storePath": storePath, "errorMessage": err.Error()})
-			fmt.Println(err)
+			fmt.Printf("%s Skipping delete.\n", err)
 			return nil
 		}
 

--- a/commands/idfinder/idfinder.go
+++ b/commands/idfinder/idfinder.go
@@ -32,7 +32,7 @@ func FindID(storePath string, pathOrID string) (string, error) {
 	}
 
 	if !exists(imagePath) {
-		return "", errorspkg.Errorf("Image `%s` not found. Skipping delete.", imageID)
+		return "", errorspkg.Errorf("Image `%s` not found.", imageID)
 	}
 
 	return imageID, nil

--- a/commands/idfinder/idfinder_test.go
+++ b/commands/idfinder/idfinder_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Idfinder", func() {
 		It("returns an error when the image does not exist", func() {
 			_, err := idfinder.FindID(storePath, filepath.Join(storePath, store.ImageDirName, "not-here"))
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("Image `not-here` not found. Skipping delete.")))
+			Expect(err).To(MatchError(ContainSubstring("Image `not-here` not found")))
 		})
 	})
 })

--- a/integration/stats_test.go
+++ b/integration/stats_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Stats", func() {
 		Context("when the last parameter is a image id", func() {
 			It("returns an error", func() {
 				_, err := Runner.Stats("invalid-id")
-				Expect(err).To(MatchError(ContainSubstring("Image `invalid-id` not found. Skipping delete.")))
+				Expect(err).To(MatchError(ContainSubstring("Image `invalid-id` not found.")))
 			})
 		})
 
@@ -202,7 +202,7 @@ var _ = Describe("Stats", func() {
 			It("returns an error", func() {
 				invalidImagePath := filepath.Join(StorePath, store.ImageDirName, "not-here")
 				_, err := Runner.Stats(invalidImagePath)
-				Expect(err).To(MatchError(ContainSubstring("Image `not-here` not found. Skipping delete.")))
+				Expect(err).To(MatchError(ContainSubstring("Image `not-here` not found.")))
 			})
 
 			Context("when the path provided doesn't belong to the `--store` provided", func() {


### PR DESCRIPTION
The ID finder now simply returns `image not found`, the deletion command elaborates.

Fixes https://github.com/cloudfoundry/garden-runc-release/issues/139.

All tests run and passing.