### PR TITLE
Bugfix: translate uid and gid in `ensureParentDir` when unpacking tar

### DIFF
--- a/base_image_puller/unpacker/tar_test.go
+++ b/base_image_puller/unpacker/tar_test.go
@@ -272,8 +272,8 @@ var _ = Describe("Tar unpacker", func() {
 					gid := info.Sys().(*syscall.Stat_t).Gid
 
 					Expect(info.Mode().String()).To(Equal("drwxr-xr-x"))
-					Expect(uid).To(Equal(uint32(0)))
-					Expect(gid).To(Equal(uint32(0)))
+					Expect(uid).To(Equal(uint32(1000)), parentDirPath)
+					Expect(gid).To(Equal(uint32(1000)), parentDirPath)
 				}
 			})
 		})
@@ -397,8 +397,8 @@ var _ = Describe("Tar unpacker", func() {
 				gid := info.Sys().(*syscall.Stat_t).Gid
 
 				Expect(info.Mode().String()).To(Equal("drwxr-xr-x"))
-				Expect(uid).To(Equal(uint32(0)))
-				Expect(gid).To(Equal(uint32(0)))
+				Expect(uid).To(Equal(uint32(1000)))
+				Expect(gid).To(Equal(uint32(1000)))
 			})
 		})
 


### PR DESCRIPTION
This bug occurs rarely, as most tar files contain all parent directories of any files they create explicitly (this is the case for docker images built with `docker build` so probably >90% are unaffected). 

But this is not required (AFAIK the original tar format doesn't even support folders). Therefore the function ``ensureParentDir`` was added in https://github.com/cloudfoundry/grootfs/commit/e9124da70cc72eac4fe4aaea5ae8b500be73653c. It will create the parent directory of files/dirs/symlinks/... if it doesn't exist and `chown` it to root. 

The problem is that it chowns it to `0` not `TranslateUID(0)` so the owner will be the host root user not the container root user.


---

~I guess this test will fail: https://github.com/sap-contributions/grootfs/blob/55643499c87708cb6bfe7c7d177a219ae197c923/base_image_puller/unpacker/tar_test.go#L253-L278, can't get it to run locally (also I don't really want to run it, I fear it will destroy my filesystem :laughing:)
Let's see what CI says.~ Don't have access to the Concourse logs, so I ran it in a VM.