### PR TITLE
Fix issues with failing tests after dependency bump

### DIFF
--- a/integration/create_docker_test.go
+++ b/integration/create_docker_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Create with remote DOCKER images", func() {
 					Mount:        mountByDefault(),
 					DiskLimit:    diskLimit,
 				})
-				Expect(err).To(MatchError(ContainSubstring("uncompressed layer size exceeds quota")))
+				Expect(err).To(MatchError(ContainSubstring("layers exceed disk quota")))
 			})
 
 			Context("when the image is not accounted for in the quota", func() {


### PR DESCRIPTION
The error message changed.

```
  [FAILED] Expected
      <*errors.errorString | 0xc00013e140>: 
      pulling the image: layers exceed disk quota 7351216/7340032 bytes
      {
          s: "pulling the image: layers exceed disk quota 7351216/7340032 bytes",
      }
  to match error
      <*matchers.ContainSubstringMatcher | 0xc000221200>: {
          Substr: "uncompressed layer size exceeds quota",
          Args: nil,
      }
  In [It] at: /tmp/build/92b78d27/repo/src/grootfs/integration/create_docker_test.go:420 @ 06/05/24 14:22:34.371

  Full Stack Trace
    code.cloudfoundry.org/grootfs/integration_test.init.func5.2.15.2()
    	/tmp/build/92b78d27/repo/src/grootfs/integration/create_docker_test.go:420 +0x3ed
```