### PR TITLE
Adjust FS metrics test for bigger cloudfoundry/garden-rootfs image

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Metrics", func() {
 
 			Expect(*metrics[0].Name).To(Equal("DownloadedLayersSizeInBytes"))
 			Expect(*metrics[0].Unit).To(Equal("bytes"))
-			Expect(*metrics[0].Value).To(BeNumerically("~", 12*1024*1024, 1*1024*1024))
+			Expect(*metrics[0].Value).To(BeNumerically("~", 13*1024*1024, 1*1024*1024))
 		})
 
 		Describe("--with-clean", func() {


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The cloudfoundry/garden-rootfs image has grown slightly due to a bigger compiled-binary footprint of golang executables going from 1.22.x to 1.23.x. Adjusting this threshold to be more tolerant of the new size.


Backward Compatibility
---------------
Breaking Change? no