### PR TITLE
Ignore G110 for app asset decompression as it's bounded by container FS quota

### DIFF
--- a/fetcher/layer_fetcher/source/layer_source.go
+++ b/fetcher/layer_fetcher/source/layer_source.go
@@ -154,6 +154,7 @@ func (s *LayerSource) Blob(logger lager.Logger, layerInfo groot.LayerInfo) (stri
 	diffIDHash := sha256.New()
 	digestReader = io.NopCloser(io.TeeReader(digestReader, diffIDHash))
 
+	// #nosec - G110 - We're fine with unbounded file decompression here as we have container filesystem quotas that will prevent this from eating up the entire diego cell disk space
 	uncompressedSize, err := io.Copy(blobTempFile, digestReader)
 	if err != nil {
 		logger.Error("writing-blob-to-file", err)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Ignores G110 becuase we have different filesystem limits guarding against this


Backward Compatibility
---------------
Breaking Change? No