### PR TITLE
Make Grootfs cleaner more resilient

### DIFF
--- a/groot/groot.go
+++ b/groot/groot.go
@@ -126,6 +126,7 @@ type StoreMeasurer interface {
 
 type Locksmith interface {
 	Lock(key string) (*os.File, error)
+	LockWithTimeout(key string, timeout time.Duration) (*os.File, error)
 	Unlock(lockFile *os.File) error
 }
 

--- a/groot/grootfakes/fake_locksmith.go
+++ b/groot/grootfakes/fake_locksmith.go
@@ -4,6 +4,7 @@ package grootfakes
 import (
 	"os"
 	"sync"
+	"time"
 
 	"code.cloudfoundry.org/grootfs/groot"
 )
@@ -19,6 +20,20 @@ type FakeLocksmith struct {
 		result2 error
 	}
 	lockReturnsOnCall map[int]struct {
+		result1 *os.File
+		result2 error
+	}
+	LockWithTimeoutStub        func(string, time.Duration) (*os.File, error)
+	lockWithTimeoutMutex       sync.RWMutex
+	lockWithTimeoutArgsForCall []struct {
+		arg1 string
+		arg2 time.Duration
+	}
+	lockWithTimeoutReturns struct {
+		result1 *os.File
+		result2 error
+	}
+	lockWithTimeoutReturnsOnCall map[int]struct {
 		result1 *os.File
 		result2 error
 	}
@@ -101,6 +116,71 @@ func (fake *FakeLocksmith) LockReturnsOnCall(i int, result1 *os.File, result2 er
 	}{result1, result2}
 }
 
+func (fake *FakeLocksmith) LockWithTimeout(arg1 string, arg2 time.Duration) (*os.File, error) {
+	fake.lockWithTimeoutMutex.Lock()
+	ret, specificReturn := fake.lockWithTimeoutReturnsOnCall[len(fake.lockWithTimeoutArgsForCall)]
+	fake.lockWithTimeoutArgsForCall = append(fake.lockWithTimeoutArgsForCall, struct {
+		arg1 string
+		arg2 time.Duration
+	}{arg1, arg2})
+	stub := fake.LockWithTimeoutStub
+	fakeReturns := fake.lockWithTimeoutReturns
+	fake.recordInvocation("LockWithTimeout", []interface{}{arg1, arg2})
+	fake.lockWithTimeoutMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeLocksmith) LockWithTimeoutCallCount() int {
+	fake.lockWithTimeoutMutex.RLock()
+	defer fake.lockWithTimeoutMutex.RUnlock()
+	return len(fake.lockWithTimeoutArgsForCall)
+}
+
+func (fake *FakeLocksmith) LockWithTimeoutCalls(stub func(string, time.Duration) (*os.File, error)) {
+	fake.lockWithTimeoutMutex.Lock()
+	defer fake.lockWithTimeoutMutex.Unlock()
+	fake.LockWithTimeoutStub = stub
+}
+
+func (fake *FakeLocksmith) LockWithTimeoutArgsForCall(i int) (string, time.Duration) {
+	fake.lockWithTimeoutMutex.RLock()
+	defer fake.lockWithTimeoutMutex.RUnlock()
+	argsForCall := fake.lockWithTimeoutArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeLocksmith) LockWithTimeoutReturns(result1 *os.File, result2 error) {
+	fake.lockWithTimeoutMutex.Lock()
+	defer fake.lockWithTimeoutMutex.Unlock()
+	fake.LockWithTimeoutStub = nil
+	fake.lockWithTimeoutReturns = struct {
+		result1 *os.File
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLocksmith) LockWithTimeoutReturnsOnCall(i int, result1 *os.File, result2 error) {
+	fake.lockWithTimeoutMutex.Lock()
+	defer fake.lockWithTimeoutMutex.Unlock()
+	fake.LockWithTimeoutStub = nil
+	if fake.lockWithTimeoutReturnsOnCall == nil {
+		fake.lockWithTimeoutReturnsOnCall = make(map[int]struct {
+			result1 *os.File
+			result2 error
+		})
+	}
+	fake.lockWithTimeoutReturnsOnCall[i] = struct {
+		result1 *os.File
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeLocksmith) Unlock(arg1 *os.File) error {
 	fake.unlockMutex.Lock()
 	ret, specificReturn := fake.unlockReturnsOnCall[len(fake.unlockArgsForCall)]
@@ -167,6 +247,8 @@ func (fake *FakeLocksmith) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.lockMutex.RLock()
 	defer fake.lockMutex.RUnlock()
+	fake.lockWithTimeoutMutex.RLock()
+	defer fake.lockWithTimeoutMutex.RUnlock()
 	fake.unlockMutex.RLock()
 	defer fake.unlockMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/store/image_manager/image_managerfakes/fake_image_driver.go
+++ b/store/image_manager/image_managerfakes/fake_image_driver.go
@@ -6,7 +6,7 @@ import (
 
 	"code.cloudfoundry.org/grootfs/groot"
 	"code.cloudfoundry.org/grootfs/store/image_manager"
-	"code.cloudfoundry.org/lager/v3"
+	lager "code.cloudfoundry.org/lager/v3"
 )
 
 type FakeImageDriver struct {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
There have been reports of the cleaner hanging for days. This results in 10k+ cleaner processes accumulating on the VM.

This change:
--> introduces a 10min cleaning timeout. if cleaning takes longer it will automatically exit.
--> introduces a 3s timeout for claiming a lock. this way 10k processes don't proliferate and keep waiting if one process hangs. the cleaner is called every few minutes anyway, it is safe not to run all of them.


Backward Compatibility
---------------
Breaking Change? No
