### PR TITLE
adjust tolerance of downloaded image

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Metrics", func() {
 
 			Expect(*metrics[0].Name).To(Equal("DownloadedLayersSizeInBytes"))
 			Expect(*metrics[0].Unit).To(Equal("bytes"))
-			Expect(*metrics[0].Value).To(BeNumerically("~", 14*1024*1024, 3*1024*1024))
+			Expect(*metrics[0].Value).To(BeNumerically("~", 18*1024*1024, 1*1024*1024))
 		})
 
 		Describe("--with-clean", func() {


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
image version bump increased the rootfs image. 

```
another error   [FAILED] Expected
      <float64>: 1.7891705e+07
  to be within 1048576 of ~
      <int>: 14680064
  In [It] at: /tmp/build/92b78d27/repo/src/grootfs/integration/metrics_test.go:154 @ 01/28/26 03:30:11.622
```
Test result:

```
••••••••••••••••••••••••••••••••••••••••• SUCCESS! 1m15.782948735s 
[1769877034] Metrics Suite - 2/2 specs - 7 procs •• SUCCESS! 31.70142ms 
[1769877034] Sandbox Suite - 11/11 specs - 7 procs ••••••••••• SUCCESS! 3.138961008s 
```

Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
